### PR TITLE
fix(helpmodal.jsx): fix link opening for gpos help section

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "prep-dist": "npm run make-build && cp electron.js build/",
     "dist": "npm run prep-dist && electron-builder -wm",
     "dist-linux": "npm run prep-dist && electron-builder -l",
-    "live": "npm run copy:electron && ELECTRON_IS_DEV=1 electron build/electron.js",
+    "live": "ELECTRON_IS_DEV=1 electron electron.js",
     "postinstall": "electron-builder install-app-deps"
   },
   "dependencies": {

--- a/src/components/Help/HelpModal.jsx
+++ b/src/components/Help/HelpModal.jsx
@@ -230,7 +230,13 @@ class HelpModal extends React.Component {
                       })
                     }
                     <Translate component='span' className='help__text' content='help.gpos.text_4'/><br/>
-                    <Translate component='span' className='help__text' content='help.gpos.text_5'/><a href={ gposLink } className='help__link--lower'>{gposLink}</a>
+                    <Translate component='span' className='help__text' content='help.gpos.text_5'/>
+                    <a onClick={ (e) => {
+                      window.open(gposLink +
+                          'Peerplays Wallet',
+                      'newwindow', 'width=500, height=400');
+                      e.preventDefault();
+                    } } href={ gposLink } className='help__link--lower'>{gposLink}</a>
                   </div>
                 </div>
 


### PR DESCRIPTION
### Purpose

(FILL ME IN) This section describes why this PR is here. Usually it would include a reference 
to the tracking task that it is part or all of the solution for.

The GitHub issue is [Create the issue if non existent and fill in]: ie: #85

## Instructions to Verify

**Steps To Reproduce:**

Steps to reproduce the behavior (example outlined below):
1. Login
2. Click "Learn More" blue text link
3. Click the hyperlink in the help modal that opens: "For more detailed help please visit https://www.peerplays.com/ppy-tokens/#peerplays-core-wallet"

**Expected Behavior**

The link should open in the browser as a new tab.

### Declarations

Check these if you believe they are true

* [X] The code base is in a better state after this PR
* [X] The level of testing this PR includes is appropriate
* [x] All tests pass using the self-service CI/Gitlab.
* [X] Changes to the codebase are well documented
* [X] Testing steps for the QA team / community is shared

### Reviewers

@MuffinLightning  @aametzler 

### Closing issues

Closes #85 Resolves GPOS-36