### PR TITLE
fix: redo math for withdrawal/deposits

### DIFF
--- a/src/actions/GPOSActions.js
+++ b/src/actions/GPOSActions.js
@@ -158,8 +158,7 @@ class GPOSActions {
           amount: {
             amount: Math.floor(requestedAmt),
             asset_id: requestedAsset
-          },
-          balance_type: BalanceTypes.gpos
+          }
         };
 
         // Build transaction

--- a/src/components/Modal/GPOSModal/DepositWithdraw/DepositWithdraw.jsx
+++ b/src/components/Modal/GPOSModal/DepositWithdraw/DepositWithdraw.jsx
@@ -279,6 +279,7 @@ class DepositWithdraw extends PureComponent {
     let {asset, action, proceedOrRegress, symbol, isBroadcasting, broadcastError, clearTransaction} =
       this.props, transactionStatus, transactionMsg, transactionMsgClass, clickAction, btnTxt, btnClass;
     transactionMsgClass = 'transaction-status__txt';
+    newAmt = newAmt >= 0 ? newAmt : 0;
 
     let rContentCardTop = (
       action === 1.2

--- a/src/components/Modal/GPOSModal/DepositWithdraw/DepositWithdraw.jsx
+++ b/src/components/Modal/GPOSModal/DepositWithdraw/DepositWithdraw.jsx
@@ -190,10 +190,10 @@ class DepositWithdraw extends PureComponent {
   }
 
   checkErrors() {
+    // Check for errors outside of the regular validation
     let {fees, maxAmount, amount, totalGpos} = this.state;
     let errors = false;
 
-    // Check for errors outside of the regular validation
     // Power Up
     if (amount !== 0) {
       if (this.props.action === 1.1) {
@@ -205,11 +205,9 @@ class DepositWithdraw extends PureComponent {
       // Power Down
       if (this.props.action === 1.2) {
         // Check if current vested balance can cover the fee
-        if (totalGpos < (fees.down)) {
+        if ((totalGpos + maxAmount) <= (fees.down)) {
           // Check if current regular balance can cover the fee
-          if (maxAmount < fees.down){
-            errors = true;
-          }
+          errors = true;
         }
       }
     }
@@ -427,7 +425,7 @@ class DepositWithdraw extends PureComponent {
     if (this.state.loading) {
       return <SLoader/>;
     } else {
-      let {asset, action} = this.props, content, title, desc, canSubmit;
+      let {asset, action} = this.props, content, title, desc, canSubmit, newAmt;
       let amt = isNaN(this.state.amount) ? 0 : this.state.amount;
       let errors = this.checkErrors();
       let actionPrefix = action === 1.1 ? 'up' : 'down';
@@ -438,12 +436,22 @@ class DepositWithdraw extends PureComponent {
       }
 
       // If action 1, power up is addition else it is action 2 which is subtraction.
-      let newAmt = action === 1.1 ? (this.state.totalGpos + amt) : (this.state.totalGpos - amt);
+      if (action === 1.1) {
+        newAmt = (this.state.totalGpos + amt);
+
+        if (this.state.maxAmount < this.state.fees.up) {
+          newAmt = newAmt - this.state.fees.up;
+        }
+      } else {
+        newAmt = this.state.totalGpos - amt;
+      }
+
+      // let newAmt = action === 1.1 ? ((this.state.totalGpos + amt) - this.state.fees.up) : (this.state.totalGpos - amt);
       newAmt = Number((newAmt).toFixed(asset.get('precision')));
       // If the number is whole, return. Else, remove trailing zeros.
       newAmt = Number.isInteger(newAmt) ? Number(newAmt.toFixed()) : newAmt;
 
-      if (newAmt !== this.state.maxAmount && amt > 0 && !errors) {
+      if (amt > 0 && !errors) {
         canSubmit = true;
       }
 

--- a/src/selectors/GPOSSelector.js
+++ b/src/selectors/GPOSSelector.js
@@ -5,8 +5,8 @@ const getGposTotal = (state) => state.dashboardPage.gposInfo.account_vested_bala
 const getAvailableGpos = (state) => state.dashboardPage.gposInfo.allowed_withdraw_amount;
 
 export const getCoreBalance = (state) => {
-  let coreToken = state.dashboardPage.coreToken;
-  return coreToken.getIn([0, 'available']);
+  let coreSymbol = state.dashboardPage.coreToken.getIn([0, 'symbol']);
+  return state.dashboardPage.availableBalances[coreSymbol].coreTokenTotal;
 };
 
 export {


### PR DESCRIPTION
### Purpose

When withdrawing gpos balance, the transaction fee
* first gets taken from the vested gpos amount being withdrawn
* if the vested gpos amount doesn’t cover the cost, then the regular balance is checked

current behaviour shows an error where there should not be one

## Instructions to Verify

**Steps To Reproduce:**

Given Available normal balance is `10` and Available GPOS balance is `10`, Transaction Fee is `20`
When user tried to withdraw `10`
Then It throws error "You don't have enough funds"

**Expected Behavior**

It shouldn't throw any error and should be able to make the transaction. Final available normal balance will be 10.

**Additional Context (optional)**

This is tested on a private testnet where the transaction fees, gpos periods, and other related configurations have been modified.

### Declarations

Check these if you believe they are true

* [x] The code base is in a better state after this PR
* [x] Is prepared according to the [Release Management & Versioning](https://github.com/peerplays-network/peerplays/wiki/Release-Management-&-Versioning)
* [x] The level of testing this PR includes is appropriate
* [x] All tests pass using the self-service CI/Gitlab.
* [x] Changes to the codebase are well documented
* [x] Testing steps for the QA team / community is shared

### Reviewers

@aametzler @MuffinLightning 

### Closing issues

Resolves GPOS-43