### PR TITLE
fix: revert prior code to have completed indicators on steps

### DIFF
--- a/src/assets/locales/locale-cn.json
+++ b/src/assets/locales/locale-cn.json
@@ -571,7 +571,6 @@
       "down": "POWER DOWN",
       "cancel": "CANCEL",
       "done": "DONE",
-      "completed": "COMPLETED",
       "submit": "SUBMIT",
       "ok": "OK",
       "finish": "FINISH",

--- a/src/assets/locales/locale-de.json
+++ b/src/assets/locales/locale-de.json
@@ -571,7 +571,6 @@
       "down": "POWER DOWN",
       "cancel": "CANCEL",
       "done": "DONE",
-      "completed": "COMPLETED",
       "submit": "SUBMIT",
       "ok": "OK",
       "finish": "FINISH",

--- a/src/assets/locales/locale-en.json
+++ b/src/assets/locales/locale-en.json
@@ -571,7 +571,6 @@
       "down": "POWER DOWN",
       "cancel": "CANCEL",
       "done": "DONE",
-      "completed": "COMPLETED",
       "submit": "SUBMIT",
       "ok": "OK",
       "finish": "FINISH",

--- a/src/assets/locales/locale-es.json
+++ b/src/assets/locales/locale-es.json
@@ -571,7 +571,6 @@
       "down": "POWER DOWN",
       "cancel": "CANCEL",
       "done": "DONE",
-      "completed": "COMPLETED",
       "submit": "SUBMIT",
       "ok": "OK",
       "finish": "FINISH",

--- a/src/assets/locales/locale-fr.json
+++ b/src/assets/locales/locale-fr.json
@@ -571,7 +571,6 @@
       "down": "POWER DOWN",
       "cancel": "CANCEL",
       "done": "DONE",
-      "completed": "COMPLETED",
       "submit": "SUBMIT",
       "ok": "OK",
       "finish": "FINISH",

--- a/src/assets/locales/locale-ko.json
+++ b/src/assets/locales/locale-ko.json
@@ -571,7 +571,6 @@
       "down": "POWER DOWN",
       "cancel": "CANCEL",
       "done": "DONE",
-      "completed": "COMPLETED",
       "submit": "SUBMIT",
       "ok": "OK",
       "finish": "FINISH",

--- a/src/assets/locales/locale-tr.json
+++ b/src/assets/locales/locale-tr.json
@@ -571,7 +571,6 @@
       "down": "POWER DOWN",
       "cancel": "CANCEL",
       "done": "DONE",
-      "completed": "COMPLETED",
       "submit": "SUBMIT",
       "ok": "OK",
       "finish": "FINISH",

--- a/src/components/Modal/GPOSModal/Start/Start.jsx
+++ b/src/components/Modal/GPOSModal/Start/Start.jsx
@@ -2,35 +2,14 @@ import React from 'react';
 import Translate from 'react-translate-component';
 
 class GposModalStart extends React.Component {
-  renderCompleted = () => {
-    return(
-      <Translate
-        component='span'
-        className='gpos-modal__card-txt completed'
-        content='gpos.modal.completed'
-      />
-    );
-  }
-
   render() {
-    let {closeModal, proceedOrRegress, completedStages, totalGpos} = this.props, hasProgress, btnTxt, canVote, canPowerDown;
+    let {closeModal, proceedOrRegress, completedStages, totalGpos} = this.props, hasProgress, btnTxt, canDo;
     hasProgress = Object.values(completedStages).indexOf(true) > -1;
     btnTxt = !hasProgress ? 'gpos.modal.cancel' : 'gpos.modal.done';
-    canPowerDown = false;
 
     // If the users' GPOS Balance is greater than 0 and they have not already voted, allow.
     if (totalGpos > 0) {
-      canVote = true;
-      canPowerDown = true;
-    }
-
-    // If vote has been completed already, disable...
-    if (completedStages['2'] === true) {
-      canVote = false;
-    }
-
-    if (completedStages['1.2'] === true) {
-      canPowerDown = false;
+      canDo = true;
     }
 
     return (
@@ -80,32 +59,29 @@ class GposModalStart extends React.Component {
           </div>
         </div>
         <div className='gpos-modal__content-right'>
-          <div disabled={ completedStages[1.1] } className='gpos-modal__card-btn' onClick={ () => proceedOrRegress(1.1) }>
+          <div className='gpos-modal__card-btn' onClick={ () => proceedOrRegress(1.1) }>
             <img className='gpos-modal__card-1' src='images/gpos/power-up.png' alt='stage1'/>
             <Translate
               component='p'
               className='gpos-modal__card-txt'
               content='gpos.start.right.1'
             />
-            {completedStages[1.1] ? this.renderCompleted(): null}
           </div>
-          <div disabled={ !canPowerDown } className='gpos-modal__card-btn' onClick={ () => proceedOrRegress(1.2) }>
+          <div disabled={ !canDo } className='gpos-modal__card-btn' onClick={ () => proceedOrRegress(1.2) }>
             <img className='gpos-modal__card-2' src='images/gpos/power-down.png' alt='stage2'/>
             <Translate
               component='p'
               className='gpos-modal__card-txt'
               content='gpos.start.right.2'
             />
-            {completedStages[1.2] ? this.renderCompleted(): null}
           </div>
-          <div disabled={ !canVote } className='gpos-modal__card-btn--no-marg' onClick={ () => proceedOrRegress(2) }>
+          <div disabled={ !canDo } className='gpos-modal__card-btn--no-marg' onClick={ () => proceedOrRegress(2) }>
             <img className='gpos-modal__card-3' src='images/gpos/vote.png' alt='stage3'/>
             <Translate
               component='p'
               className='gpos-modal__card-txt'
               content='gpos.start.right.3'
             />
-            {completedStages[2] ? this.renderCompleted(): null}
           </div>
           <div className='gpos-modal__btns'>
             <button className='gpos-modal__btn-cancel' onClick={ closeModal }>

--- a/src/components/Modal/GPOSModal/Start/Start.jsx
+++ b/src/components/Modal/GPOSModal/Start/Start.jsx
@@ -3,9 +3,10 @@ import Translate from 'react-translate-component';
 
 class GposModalStart extends React.Component {
   render() {
-    let {closeModal, proceedOrRegress, completedStages, totalGpos} = this.props, hasProgress, btnTxt, canDo;
-    hasProgress = Object.values(completedStages).indexOf(true) > -1;
-    btnTxt = !hasProgress ? 'gpos.modal.cancel' : 'gpos.modal.done';
+    const {closeModal, proceedOrRegress, completedStages, totalGpos} = this.props;
+    let hasProgress = Object.values(completedStages).indexOf(true) > -1;
+    let btnTxt = !hasProgress ? 'gpos.modal.cancel' : 'gpos.modal.done';
+    let canDo = false;
 
     // If the users' GPOS Balance is greater than 0 and they have not already voted, allow.
     if (totalGpos > 0) {


### PR DESCRIPTION
### Purpose

Following changes/issues needs to be done in Get Started/Participate modal
* Completed state indicator is not necessary and it needs to be removed
* User actions -> Power Up, Power Down and Vote buttons are disabled after the corresponding action is performed.
* State of the buttons is not reset even after closing and opening Get Started/Participate modal. It will be done only after log out and log in to app.

The GitHub issue is [Create the issue if non existent and fill in]: ie: #89 

## Instructions to Verify

**Steps To Reproduce:**

1. Go to right side menu from dashboard and click get started/participate

**Expected Behavior**

* No completed state indicators
* User actions -> Power Up, Power Down and Vote buttons should not be disabled after the action is performed. user should be able to perform these actions as many times he wants.

**Additional Context (optional)**

This is tested on a private testnet where the transaction fees, gpos periods, and other related configurations have been modified.
New designs never had a decision made that included newer completed state indicators so they have been
removed. 

### Declarations

Check these if you believe they are true

* [ ] The code base is in a better state after this PR
* [ ] Is prepared according to the [Release Management & Versioning](https://github.com/peerplays-network/peerplays/wiki/Release-Management-&-Versioning)
* [ ] The level of testing this PR includes is appropriate
* [ ] All tests pass using the self-service CI/Gitlab.
* [ ] Changes to the codebase are well documented
* [ ] Testing steps for the QA team / community is shared

### Reviewers

@MuffinLightning @aametzler 

### Closing issues

Closes #89 Resolves GPOS-51