### PR TITLE
fix: block entry of 'e', 'E', '-', & '+'

### DIFF
--- a/src/components/Modal/GPOSModal/DepositWithdraw/DepositWithdraw.jsx
+++ b/src/components/Modal/GPOSModal/DepositWithdraw/DepositWithdraw.jsx
@@ -151,6 +151,12 @@ class DepositWithdraw extends PureComponent {
     }
   }
 
+  onInvalidKey = (e) => {
+    if (e.key === 'e' || e.key === '-' || e.key === '+') {
+      e.preventDefault();
+    }
+  }
+
   // Handle manually entered values here
   onEdit = (e) => {
     let val;
@@ -263,6 +269,7 @@ class DepositWithdraw extends PureComponent {
               value={ this.state.amount }
               onChange={ this.onEdit }
               onBlur={ this.onEdit }
+              onKeyDown={ this.onInvalidKey }
               tabIndex='0'
               min='0'
               max={ max }

--- a/src/components/Modal/GPOSModal/DepositWithdraw/DepositWithdraw.jsx
+++ b/src/components/Modal/GPOSModal/DepositWithdraw/DepositWithdraw.jsx
@@ -151,8 +151,21 @@ class DepositWithdraw extends PureComponent {
     }
   }
 
+  // Block manual key entering of 'e', '-', & '+'
   onInvalidKey = (e) => {
     if (e.key === 'e' || e.key === '-' || e.key === '+') {
+      e.preventDefault();
+    }
+  }
+
+  // Block clipboard pasted entry of 'e', 'E', '-', & '+'
+  onPaste = (e) => {
+    // Define regex that matches 'e', 'E', '-', & '+'
+    const regex = RegExp(/[eE\-\+]/g);
+    const data = e.clipboardData.getData('Text');
+
+    if (regex.test(data)) {
+      e.stopPropagation();
       e.preventDefault();
     }
   }
@@ -270,6 +283,7 @@ class DepositWithdraw extends PureComponent {
               onChange={ this.onEdit }
               onBlur={ this.onEdit }
               onKeyDown={ this.onInvalidKey }
+              onPaste={ this.onPaste }
               tabIndex='0'
               min='0'
               max={ max }

--- a/src/components/Modal/GPOSModal/DepositWithdraw/DepositWithdraw.jsx
+++ b/src/components/Modal/GPOSModal/DepositWithdraw/DepositWithdraw.jsx
@@ -153,7 +153,7 @@ class DepositWithdraw extends PureComponent {
 
   // Block manual key entering of 'e', '-', & '+'
   onInvalidKey = (e) => {
-    if (e.key === 'e' || e.key === '-' || e.key === '+') {
+    if (e.key === 'e' || e.key === 'E' || e.key === '-' || e.key === '+') {
       e.preventDefault();
     }
   }


### PR DESCRIPTION
### Purpose
Prevent a user from entering 'e', 'E', '-', and/or '+'

The GitHub issue is: #88 

## Instructions to Verify

**Steps To Reproduce:**

1. Go to far right menu on dashboard and click Participate/Get Started
2. Click Power Down or Power Up
3. Enter 'e', '-', and '+' into the form input field
4. Copy some text containing the values in step 3 and paste it into the form input field

**Expected Behavior**

Entry of 'e', '-', & '+' is not allowed.

**Additional Context (optional)**

Clipboard events for entry of 'e', '-', '&' + have also been disabled.

### Declarations

Check these if you believe they are true

* [x] The code base is in a better state after this PR
* [x] Is prepared according to the [Release Management & Versioning](https://github.com/peerplays-network/peerplays/wiki/Release-Management-&-Versioning)
* [x] The level of testing this PR includes is appropriate
* [x] All tests pass using the self-service CI/Gitlab.
* [x] Changes to the codebase are well documented
* [x] Testing steps for the QA team / community is shared

### Reviewers

@MuffinLightning @aametzler 

### Closing issues

Closes #88 
Resolves GPOS-49