### PR TITLE
Vote modal - Published change is not retained on switching tabs

### DIFF
--- a/src/components/Voting/VotingContainer.jsx
+++ b/src/components/Voting/VotingContainer.jsx
@@ -59,27 +59,30 @@ class VotingContainer extends React.Component {
 
   render() {
     let selectedIndex = this.state.selectedTab;
+    let content = () => <Tabs
+      className='pt40'
+      onSelect={ this.onChangeActiveMenuItem.bind(this) }
+      selectedIndex={ selectedIndex }>
+      <TabList>
+        <Tab selected={ selectedIndex === 0 }><Translate content='votes.proxy_short'/></Tab>
+        <Tab selected={ selectedIndex === 1 }><Translate content='votes.add_witness_label'/></Tab>
+        <Tab selected={ selectedIndex === 2 }><Translate content='votes.advisors'/></Tab>
+      </TabList>
+
+      <TabPanel><Proxy renderHandlers={ this.renderHandlerButtons }/></TabPanel>
+      <TabPanel><Witnesses renderHandlers={ this.renderHandlerButtons }/></TabPanel>
+      <TabPanel><CommitteeMembers renderHandlers={ this.renderHandlerButtons }/></TabPanel>
+    </Tabs>;
+
+    if (!this.state.loaded) {
+      content = () => <SLoader/>;
+    }
 
     return (
       <div className='main'>
         <section className='content'>
           <div className='box'>
-            {this.state.loaded
-              ? <Tabs
-                className='pt40'
-                onSelect={ this.onChangeActiveMenuItem.bind(this) }
-                selectedIndex={ selectedIndex }>
-                <TabList>
-                  <Tab selected={ selectedIndex === 0 }><Translate content='votes.proxy_short'/></Tab>
-                  <Tab selected={ selectedIndex === 1 }><Translate content='votes.add_witness_label'/></Tab>
-                  <Tab selected={ selectedIndex === 2 }><Translate content='votes.advisors'/></Tab>
-                </TabList>
-                <TabPanel><Proxy renderHandlers={ this.renderHandlerButtons }/></TabPanel>
-                <TabPanel><Witnesses renderHandlers={ this.renderHandlerButtons }/></TabPanel>
-                <TabPanel><CommitteeMembers renderHandlers={ this.renderHandlerButtons }/></TabPanel>
-              </Tabs>
-              : <SLoader/>
-            }
+            {content()}
           </div>
         </section>
       </div>

--- a/src/components/Voting/Witnesses.jsx
+++ b/src/components/Voting/Witnesses.jsx
@@ -30,6 +30,25 @@ class Witnesses extends React.Component {
     this.debounceOnInputChange = _.debounce(this.checkAccount.bind(this), 500);
   }
 
+  componentWillMount() {
+    this.props.fetchData().then(() => {
+      this.setState({witnesses: this.props.approvedWitnesseIds});
+    });
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.walletLocked !== this.props.walletLocked && !prevProps.walletLocked) {
+      this.onPublishChanges(prevProps.walletLocked);
+    }
+
+    if (JSON.stringify(prevProps.approvedWitnesseIds) !== JSON.stringify(this.props.approvedWitnesseIds)) {
+      this.setState({
+        witnesses: prevProps.approvedWitnesseIds,
+        prev_witnesses: prevProps.approvedWitnesseIds
+      });
+    }
+  }
+
   checkAccount() {
     if (this.state.item_name_input.trim().length) {
       this.verifyInputValue(this.state.item_name_input.trim(), this.uniqueRequestId);
@@ -511,6 +530,7 @@ const mapDispatchToProps = (dispatch) => bindActionCreators(
     publishWitnesses: VotingActions.publishWitnesses,
     addNewWitnessData: VotingActions.addNewWitnessData,
     fetchWitnessData: VotingActions.fetchWitnessData,
+    fetchData: VotingActions.fetchData,
     setTransaction: RTransactionConfirmActions.setTransaction
   },
   dispatch

--- a/src/components/Voting/Witnesses.jsx
+++ b/src/components/Voting/Witnesses.jsx
@@ -36,19 +36,6 @@ class Witnesses extends React.Component {
     });
   }
 
-  componentDidUpdate(prevProps) {
-    if (prevProps.walletLocked !== this.props.walletLocked && !prevProps.walletLocked) {
-      this.onPublishChanges(prevProps.walletLocked);
-    }
-
-    if (JSON.stringify(prevProps.approvedWitnesseIds) !== JSON.stringify(this.props.approvedWitnesseIds)) {
-      this.setState({
-        witnesses: prevProps.approvedWitnesseIds,
-        prev_witnesses: prevProps.approvedWitnesseIds
-      });
-    }
-  }
-
   checkAccount() {
     if (this.state.item_name_input.trim().length) {
       this.verifyInputValue(this.state.item_name_input.trim(), this.uniqueRequestId);


### PR DESCRIPTION
### Purpose

Vote modal - Published change is not retained on switching tabs

The GitHub issue is [Create the issue if non existent and fill in]: ie: #90 

## Instructions to Verify

**Steps To Reproduce:**

1. Login to wallet, vest balance if gpos balance is 0
2. Navigate to vote modal -> select witness tab
3. Vote for some witness, witness will show up under Witnesses approved by <<user>>
4. Click on Advisors tab and then click on Witness tab 

**Expected Behavior**

state after step 3 should exist

### Declarations

Check these if you believe they are true

* [x] The code base is in a better state after this PR
* [x] The level of testing this PR includes is appropriate
* [x] All tests pass using the self-service CI/Gitlab.
* [x] Changes to the codebase are well documented
* [x] Testing steps for the QA team / community is shared

### Reviewers

@MuffinLightning @aametzler 

### Closing issues

Closes #90 
Resolved GPOS-50