### PR TITLE
fix(proxy.jsx): publish button of proxy modal remains disabled

### DIFF
--- a/src/components/Voting/Proxy.jsx
+++ b/src/components/Voting/Proxy.jsx
@@ -154,7 +154,7 @@ class Proxy extends React.Component {
   }
 
   render() {
-    let {inputName, name, error, requestInProcess, disabled} = this.state;
+    const {inputName, name, error, requestInProcess, disabled} = this.state;
     let {account} = this.props;
 
     return (

--- a/src/components/Voting/Proxy.jsx
+++ b/src/components/Voting/Proxy.jsx
@@ -16,6 +16,7 @@ class Proxy extends React.Component {
     this.state = {
       inputName: '',
       name: props.name,
+      disabled: true,
       error: null,
       requestInProcess: false
     };
@@ -104,6 +105,9 @@ class Proxy extends React.Component {
                 voting_account: proxy.id,
                 transactionFunction: VotingActions.holdTransaction,
                 functionArguments: tr,
+                transactionFunctionCallback: () => {
+                  this.setState({disabled: true});
+                },
                 proposedOperation: `Update account for ${this.props.account}`,
                 fee: {
                   amount: tr.operations[0][1].fee.amount,
@@ -138,21 +142,20 @@ class Proxy extends React.Component {
   }
 
   onResetChanges() {
-    this.setState({name: this.props.name});
+    this.setState({name: this.props.name, disabled: false});
   }
 
   onRemoveProxy() {
-    this.setState({name: ''});
+    this.setState({name: '', disabled: false});
   }
 
   addProxy() {
-    this.setState({name: this.state.inputName, inputName: ''});
+    this.setState({name: this.state.inputName, inputName: '', disabled: false});
   }
 
   render() {
-    let {inputName, name, error, requestInProcess} = this.state;
+    let {inputName, name, error, requestInProcess, disabled} = this.state;
     let {account} = this.props;
-    let disabled = this.props.name === this.state.name;
 
     return (
       <div


### PR DESCRIPTION
### Purpose

Publish button of Proxy modal remains disabled when we cancel to publish the changes

The GitHub issue is: #87

## Instructions to Verify

**Steps To Reproduce:**

Proxy is already set → Type account name as proxy → click on add button → click on the publish button → click on the cancel button

**Expected Behavior**

A user should be able to cancel the confirmation window and still click the publish button.

### Declarations

Check these if you believe they are true

* [ ] The code base is in a better state after this PR
* [ ] The level of testing this PR includes is appropriate
* [ ] All tests pass using the self-service CI/Gitlab.
* [ ] Changes to the codebase are well documented
* [ ] Testing steps for the QA team / community is shared

### Reviewers

@MuffinLightning @aametzler 

### Closing issues

Closes: #87 
Resolved GPOS-53 