### PR TITLE
fix(done.jsx): participation Dialogue Not Displayed after voting->done

### DIFF
--- a/src/components/Modal/GPOSModal/Done/Done.jsx
+++ b/src/components/Modal/GPOSModal/Done/Done.jsx
@@ -7,7 +7,6 @@ import {GPOSActions} from '../../../../actions';
 class Done extends React.PureComponent {
   doneHandler = () => {
     this.props.okHandler(0);
-    this.props.toggleGPOSModal();
   }
 
   render() {

--- a/src/components/Modal/GPOSModal/Done/Done.jsx
+++ b/src/components/Modal/GPOSModal/Done/Done.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import {connect} from 'react-redux';
 import Translate from 'react-translate-component';
-import {bindActionCreators} from 'redux';
-import {GPOSActions} from '../../../../actions';
 
 class Done extends React.PureComponent {
   doneHandler = () => {
@@ -56,11 +54,4 @@ class Done extends React.PureComponent {
   }
 }
 
-const mapDispatchToProps = (dispatch) => bindActionCreators(
-  {
-    toggleGPOSModal: GPOSActions.toggleGPOSModal
-  },
-  dispatch
-);
-
-export default connect(null, mapDispatchToProps)(Done);
+export default connect(null, null)(Done);


### PR DESCRIPTION
### Purpose

After voting, "Thank you for Voting" dialog will be open. Click on the OK button land the user to the Home page. 

The GitHub issue is: #86

## Instructions to Verify

**Steps To Reproduce:**

1. Click Get Started/Participate in right hand menu on Dashboard
2. Click Vote
3. Click Finish
4. Click OK

**Expected Behavior**

Click on the OK button should land the user back to the Participation page.

### Declarations

Check these if you believe they are true

* [x] The code base is in a better state after this PR
* [x] The level of testing this PR includes is appropriate
* [x] All tests pass using the self-service CI/Gitlab.
* [x] Changes to the codebase are well documented
* [x] Testing steps for the QA team / community is shared

### Reviewers

@MuffinLightning @aametzler 

### Closing issues

Closes #86
Resolves GPOS-52