### PR TITLE
GPOS-62: GPOS vesting balances are displayed under claim balance

### DIFF
--- a/src/components/Account/Vesting/VestingAccountContainer.jsx
+++ b/src/components/Account/Vesting/VestingAccountContainer.jsx
@@ -77,7 +77,7 @@ class VestingAccountContainer extends React.Component {
 
 const mapStateToProps = (state) => {
   return {
-    balances: state.accountVestingPageReducer.balances
+    balances: state.accountVestingPageReducer.otherBalances
   };
 };
 

--- a/src/reducers/AccountVestingPageReducer.js
+++ b/src/reducers/AccountVestingPageReducer.js
@@ -7,7 +7,8 @@ import ActionTypes from '../constants/ActionTypes';
  * @type {{balances: Array}}
  */
 let defaultState = {
-  balances: []
+  balances: [],
+  otherBalances: []
 };
 
 export default function (state = defaultState, action) {
@@ -15,7 +16,8 @@ export default function (state = defaultState, action) {
     // Set account vesting list
     case ActionTypes.SET_ACCOUNT_VESTING_DATA:
       return Object.assign({}, state, {
-        balances: action.payload.balances
+        balances: action.payload.balances,
+        otherBalances: action.payload.otherBalances
       });
       // Reset page
     case ActionTypes.RESET_ACCOUNT_VESTING_DATA:


### PR DESCRIPTION
### Purpose

GPOS vesting balances are displayed under claim balance

## Instructions to Verify

**Steps To Reproduce:**

1. Login with a witness account which has non GPOS vesting balance
2. Under Pending Balances, Click on "CLAIM BALANCES"

**Expected Behavior**

Only non-GPOS vesting balances should be displayed
Actual: GPOS vesting balances are displayed

### Declarations

Check these if you believe they are true

* [x] The code base is in a better state after this PR
* [x] The level of testing this PR includes is appropriate
* [x] All tests pass using the self-service CI/Gitlab.
* [x] Changes to the codebase are well documented
* [x] Testing steps for the QA team / community is shared

### Reviewers

@aametzler 

### Closing issues

Resolves GPOS-62