### PR TITLE
feat(witnesslist.jsx): table column sorting

### DIFF
--- a/src/assets/stylesheets/modules/_table.scss
+++ b/src/assets/stylesheets/modules/_table.scss
@@ -445,6 +445,22 @@
     border-bottom: 1px solid $th-bd-color;
     color: $th-color;
 
+    &.sort {
+      cursor: pointer;
+
+      &--true, &--false, &--default {
+        @extend .tableCell.sort;
+      }
+
+      &--true::after { // ascend
+        content: ' ▲';
+      }
+
+      &--false::after { // descend
+        content: ' ▼';
+      }
+    }
+
     &:first-child {
       @include border-radius(4px 0 0 0);
     }
@@ -452,6 +468,12 @@
     &:last-child {
       @include border-radius(0 4px 0 0);
     }
+  }
+}
+
+.table-voting-witnesses2 .tableRow {
+  &.sortable {
+    cursor: pointer;
   }
 }
 

--- a/src/components/Voting/WitnessList.jsx
+++ b/src/components/Voting/WitnessList.jsx
@@ -2,13 +2,15 @@ import React from 'react';
 import Translate from 'react-translate-component';
 import {connect} from 'react-redux';
 import WitnessRow from './WitnessRow';
+import Utils from '../../common/utils';
 
 class WitnessListNew extends React.Component {
   state = {
     initialRowData: [],
     rowData: [],
     ranks: [],
-    sortDirections: { // true = ascend, false = descend
+    sortDirections: {
+      // true = ascend, false = descend
       rank: 'default',
       name: 'default',
       last_block: 'default',
@@ -16,66 +18,65 @@ class WitnessListNew extends React.Component {
       total_missed: 'default',
       votes: 'default'
     }
-  }
+  };
 
   componentDidMount() {
     // Get initial data and set to state
-    let {activeWitnesseAccounts, activeWitnesseObjects} = this.props;
+    const {activeWitnesseAccounts, activeWitnesseObjects} = this.props;
     let most_recent_aslot = 0;
     let ranks = {};
     let witnesses = activeWitnesseObjects;
 
-    witnesses.sort((a, b) => {
-      if (a && b) {
-        return parseInt(b.total_votes, 10) - parseInt(a.total_votes, 10);
-      }
-
-      return null;
-    }).forEach( (w, index) => {
-      if (w) {
-        let s = w.last_aslot;
-
-        if (most_recent_aslot < s) {
-          most_recent_aslot = s;
+    witnesses
+      .sort((a, b) => {
+        if (a && b) {
+          return parseInt(b.total_votes, 10) - parseInt(a.total_votes, 10);
         }
 
-        ranks[w.id] = index + 1;
-      }
-    });
+        return null;
+      })
+      .forEach((w, index) => {
+        if (w) {
+          let s = w.last_aslot;
+
+          if (most_recent_aslot < s) {
+            most_recent_aslot = s;
+          }
+
+          ranks[w.id] = index + 1;
+        }
+      });
 
     let itemRows = null;
 
     if (witnesses.size > 0) {
-      itemRows = witnesses.filter((a) => {
-        if (!a) {
-          return false;
-        }
+      itemRows = witnesses
+        .filter((a) => {
+          if (!a) {
+            return false;
+          }
 
-        let account = activeWitnesseAccounts.get(a.witness_account);
+          let account = activeWitnesseAccounts.get(a.witness_account);
 
-        if (!account) {
-          return false;
-        }
+          if (!account) {
+            return false;
+          }
 
-        let name = account.name;
+          let name = account.name;
 
-        if (!name) {
-          return false;
-        }
+          if (!name) {
+            return false;
+          }
 
-        return true;
-      }).map((a) => {
-        let a_account = activeWitnesseAccounts.get(a.witness_account);
+          return true;
+        })
+        .map((a) => {
+          let a_account = activeWitnesseAccounts.get(a.witness_account);
 
-        return (
-          <WitnessRow
-            key={ a.id }
-            rank={ ranks[a.id] }
-            witnessAccount={ a_account }
-            witness={ a }
-          />
-        );
-      });
+          return (
+            <WitnessRow key={ a.id } rank={ ranks[a.id] } witnessAccount={ a_account } witness={ a } />
+          );
+        });
 
       this.setState({
         initialRowData: itemRows,
@@ -90,7 +91,7 @@ class WitnessListNew extends React.Component {
     // Determine column accessor
     let accessor;
 
-    switch(col) {
+    switch (col) {
       case 'rank':
         accessor = 'props.rank';
         break;
@@ -129,14 +130,16 @@ class WitnessListNew extends React.Component {
     }
 
     // Get current sort direction for clicked column header and invert (setState is async so no guarantee it has updated)
-    let sortedItemRows = this.state.rowData.sort((a, b) => {
-      let aValue = this.getAccessor(a, accessor);
-      let bValue = this.getAccessor(b, accessor);
+    const sortedItemRows = this.state.rowData.sort((a, b) => {
+      const aValue = this.getAccessor(a, accessor);
+      const bValue = this.getAccessor(b, accessor);
 
-      if (newSortDir[col]) {
-        return aValue > bValue ? 1 : -1;
-      } else if (!newSortDir[col]) {
-        return aValue < bValue ? 1 : -1;
+      if (Utils.isEmptyObject(aValue) && Utils.isEmptyObject(bValue)) {
+        if (newSortDir[col]) {
+          return aValue > bValue ? 1 : -1;
+        } else if (!newSortDir[col]) {
+          return aValue < bValue ? 1 : -1;
+        }
       }
 
       return this.state.initialRowData; // return initial data
@@ -146,11 +149,11 @@ class WitnessListNew extends React.Component {
       sortDirections: newSortDir, // Invert sort direction
       rowData: sortedItemRows
     });
-  }
+  };
 
   getAccessor = (obj, str) => {
     str = str.replace(/\[(\w+)\]/g, '.$1'); // convert indexes to properties
-    str = str.replace(/^\./, '');           // strip a leading dot
+    str = str.replace(/^\./, ''); // strip a leading dot
     var a = str.split('.');
 
     for (var i = 0, n = a.length; i < n; ++i) {
@@ -159,12 +162,12 @@ class WitnessListNew extends React.Component {
       if (k in obj) {
         obj = obj[k];
       } else {
-        return;
+        return {};
       }
     }
 
     return obj;
-  }
+  };
 
   render() {
     const {rowData, sortDirections} = this.state;
@@ -173,16 +176,44 @@ class WitnessListNew extends React.Component {
       <div>
         <div className='table table2 table-voting-witnesses2'>
           <div className='table__head tableRow'>
-            <div className={ `tableCell sort--${sortDirections.rank}` } onClick={ () => this.sortBy('rank') }><Translate content='witnesses.rank'/></div>
-            <div className={ `tableCell sort--${sortDirections.name}` } onClick={ () => this.sortBy('name') }><Translate content='votes.name'/></div>
-            <div className={ `tableCell text_r sort--${sortDirections.last_block}` } onClick={ () => this.sortBy('last_block') }><Translate content='witnesses.last_block'/></div>
-            <div className={ `tableCell text_r sort--${sortDirections.last_confirmed}` } onClick={ () => this.sortBy('last_confirmed') }><Translate content='witnesses.last_confirmed'/></div>
-            <div className={ `tableCell text_r sort--${sortDirections.total_missed}` } onClick={ () => this.sortBy('total_missed') }><Translate content='witnesses.missed'/></div>
-            <div className={ `tableCell text_r sort--${sortDirections.votes}` } onClick={ () => this.sortBy('votes') }><Translate content='votes.votes'/></div>
+            <div
+              className={ `tableCell sort--${sortDirections.rank}` }
+              onClick={ () => this.sortBy('rank') }
+            >
+              <Translate content='witnesses.rank' />
+            </div>
+            <div
+              className={ `tableCell sort--${sortDirections.name}` }
+              onClick={ () => this.sortBy('name') }
+            >
+              <Translate content='votes.name' />
+            </div>
+            <div
+              className={ `tableCell text_r sort--${sortDirections.last_block}` }
+              onClick={ () => this.sortBy('last_block') }
+            >
+              <Translate content='witnesses.last_block' />
+            </div>
+            <div
+              className={ `tableCell text_r sort--${sortDirections.last_confirmed}` }
+              onClick={ () => this.sortBy('last_confirmed') }
+            >
+              <Translate content='witnesses.last_confirmed' />
+            </div>
+            <div
+              className={ `tableCell text_r sort--${sortDirections.total_missed}` }
+              onClick={ () => this.sortBy('total_missed') }
+            >
+              <Translate content='witnesses.missed' />
+            </div>
+            <div
+              className={ `tableCell text_r sort--${sortDirections.votes}` }
+              onClick={ () => this.sortBy('votes') }
+            >
+              <Translate content='votes.votes' />
+            </div>
           </div>
-          <div className='table__body'>
-            {rowData}
-          </div>
+          <div className='table__body'>{rowData}</div>
         </div>
       </div>
     );
@@ -191,9 +222,9 @@ class WitnessListNew extends React.Component {
 
 const mapStateToProps = (state) => {
   return {
-    current : state.voting.witnesses.currentWitnessId,
-    activeWitnesseObjects : state.voting.witnesses.activeWitnesseObjects,
-    activeWitnesseAccounts : state.voting.witnesses.activeWitnesseAccounts
+    current: state.voting.witnesses.currentWitnessId,
+    activeWitnesseObjects: state.voting.witnesses.activeWitnesseObjects,
+    activeWitnesseAccounts: state.voting.witnesses.activeWitnesseAccounts
   };
 };
 

--- a/src/components/Voting/WitnessList.jsx
+++ b/src/components/Voting/WitnessList.jsx
@@ -2,15 +2,13 @@ import React from 'react';
 import Translate from 'react-translate-component';
 import {connect} from 'react-redux';
 import WitnessRow from './WitnessRow';
-import Utils from '../../common/utils';
 
 class WitnessListNew extends React.Component {
   state = {
     initialRowData: [],
     rowData: [],
     ranks: [],
-    sortDirections: {
-      // true = ascend, false = descend
+    sortDirections: { // true = ascend, false = descend
       rank: 'default',
       name: 'default',
       last_block: 'default',
@@ -18,65 +16,66 @@ class WitnessListNew extends React.Component {
       total_missed: 'default',
       votes: 'default'
     }
-  };
+  }
 
   componentDidMount() {
     // Get initial data and set to state
-    const {activeWitnesseAccounts, activeWitnesseObjects} = this.props;
+    let {activeWitnesseAccounts, activeWitnesseObjects} = this.props;
     let most_recent_aslot = 0;
     let ranks = {};
     let witnesses = activeWitnesseObjects;
 
-    witnesses
-      .sort((a, b) => {
-        if (a && b) {
-          return parseInt(b.total_votes, 10) - parseInt(a.total_votes, 10);
+    witnesses.sort((a, b) => {
+      if (a && b) {
+        return parseInt(b.total_votes, 10) - parseInt(a.total_votes, 10);
+      }
+
+      return null;
+    }).forEach( (w, index) => {
+      if (w) {
+        let s = w.last_aslot;
+
+        if (most_recent_aslot < s) {
+          most_recent_aslot = s;
         }
 
-        return null;
-      })
-      .forEach((w, index) => {
-        if (w) {
-          let s = w.last_aslot;
-
-          if (most_recent_aslot < s) {
-            most_recent_aslot = s;
-          }
-
-          ranks[w.id] = index + 1;
-        }
-      });
+        ranks[w.id] = index + 1;
+      }
+    });
 
     let itemRows = null;
 
     if (witnesses.size > 0) {
-      itemRows = witnesses
-        .filter((a) => {
-          if (!a) {
-            return false;
-          }
+      itemRows = witnesses.filter((a) => {
+        if (!a) {
+          return false;
+        }
 
-          let account = activeWitnesseAccounts.get(a.witness_account);
+        let account = activeWitnesseAccounts.get(a.witness_account);
 
-          if (!account) {
-            return false;
-          }
+        if (!account) {
+          return false;
+        }
 
-          let name = account.name;
+        let name = account.name;
 
-          if (!name) {
-            return false;
-          }
+        if (!name) {
+          return false;
+        }
 
-          return true;
-        })
-        .map((a) => {
-          let a_account = activeWitnesseAccounts.get(a.witness_account);
+        return true;
+      }).map((a) => {
+        let a_account = activeWitnesseAccounts.get(a.witness_account);
 
-          return (
-            <WitnessRow key={ a.id } rank={ ranks[a.id] } witnessAccount={ a_account } witness={ a } />
-          );
-        });
+        return (
+          <WitnessRow
+            key={ a.id }
+            rank={ ranks[a.id] }
+            witnessAccount={ a_account }
+            witness={ a }
+          />
+        );
+      });
 
       this.setState({
         initialRowData: itemRows,
@@ -91,7 +90,7 @@ class WitnessListNew extends React.Component {
     // Determine column accessor
     let accessor;
 
-    switch (col) {
+    switch(col) {
       case 'rank':
         accessor = 'props.rank';
         break;
@@ -130,16 +129,14 @@ class WitnessListNew extends React.Component {
     }
 
     // Get current sort direction for clicked column header and invert (setState is async so no guarantee it has updated)
-    const sortedItemRows = this.state.rowData.sort((a, b) => {
-      const aValue = this.getAccessor(a, accessor);
-      const bValue = this.getAccessor(b, accessor);
+    let sortedItemRows = this.state.rowData.sort((a, b) => {
+      let aValue = this.getAccessor(a, accessor);
+      let bValue = this.getAccessor(b, accessor);
 
-      if (Utils.isEmptyObject(aValue) && Utils.isEmptyObject(bValue)) {
-        if (newSortDir[col]) {
-          return aValue > bValue ? 1 : -1;
-        } else if (!newSortDir[col]) {
-          return aValue < bValue ? 1 : -1;
-        }
+      if (newSortDir[col]) {
+        return aValue > bValue ? 1 : -1;
+      } else if (!newSortDir[col]) {
+        return aValue < bValue ? 1 : -1;
       }
 
       return this.state.initialRowData; // return initial data
@@ -149,11 +146,11 @@ class WitnessListNew extends React.Component {
       sortDirections: newSortDir, // Invert sort direction
       rowData: sortedItemRows
     });
-  };
+  }
 
   getAccessor = (obj, str) => {
     str = str.replace(/\[(\w+)\]/g, '.$1'); // convert indexes to properties
-    str = str.replace(/^\./, ''); // strip a leading dot
+    str = str.replace(/^\./, '');           // strip a leading dot
     var a = str.split('.');
 
     for (var i = 0, n = a.length; i < n; ++i) {
@@ -162,12 +159,12 @@ class WitnessListNew extends React.Component {
       if (k in obj) {
         obj = obj[k];
       } else {
-        return {};
+        return;
       }
     }
 
     return obj;
-  };
+  }
 
   render() {
     const {rowData, sortDirections} = this.state;
@@ -176,44 +173,16 @@ class WitnessListNew extends React.Component {
       <div>
         <div className='table table2 table-voting-witnesses2'>
           <div className='table__head tableRow'>
-            <div
-              className={ `tableCell sort--${sortDirections.rank}` }
-              onClick={ () => this.sortBy('rank') }
-            >
-              <Translate content='witnesses.rank' />
-            </div>
-            <div
-              className={ `tableCell sort--${sortDirections.name}` }
-              onClick={ () => this.sortBy('name') }
-            >
-              <Translate content='votes.name' />
-            </div>
-            <div
-              className={ `tableCell text_r sort--${sortDirections.last_block}` }
-              onClick={ () => this.sortBy('last_block') }
-            >
-              <Translate content='witnesses.last_block' />
-            </div>
-            <div
-              className={ `tableCell text_r sort--${sortDirections.last_confirmed}` }
-              onClick={ () => this.sortBy('last_confirmed') }
-            >
-              <Translate content='witnesses.last_confirmed' />
-            </div>
-            <div
-              className={ `tableCell text_r sort--${sortDirections.total_missed}` }
-              onClick={ () => this.sortBy('total_missed') }
-            >
-              <Translate content='witnesses.missed' />
-            </div>
-            <div
-              className={ `tableCell text_r sort--${sortDirections.votes}` }
-              onClick={ () => this.sortBy('votes') }
-            >
-              <Translate content='votes.votes' />
-            </div>
+            <div className={ `tableCell sort--${sortDirections.rank}` } onClick={ () => this.sortBy('rank') }><Translate content='witnesses.rank'/></div>
+            <div className={ `tableCell sort--${sortDirections.name}` } onClick={ () => this.sortBy('name') }><Translate content='votes.name'/></div>
+            <div className={ `tableCell text_r sort--${sortDirections.last_block}` } onClick={ () => this.sortBy('last_block') }><Translate content='witnesses.last_block'/></div>
+            <div className={ `tableCell text_r sort--${sortDirections.last_confirmed}` } onClick={ () => this.sortBy('last_confirmed') }><Translate content='witnesses.last_confirmed'/></div>
+            <div className={ `tableCell text_r sort--${sortDirections.total_missed}` } onClick={ () => this.sortBy('total_missed') }><Translate content='witnesses.missed'/></div>
+            <div className={ `tableCell text_r sort--${sortDirections.votes}` } onClick={ () => this.sortBy('votes') }><Translate content='votes.votes'/></div>
           </div>
-          <div className='table__body'>{rowData}</div>
+          <div className='table__body'>
+            {rowData}
+          </div>
         </div>
       </div>
     );
@@ -222,9 +191,9 @@ class WitnessListNew extends React.Component {
 
 const mapStateToProps = (state) => {
   return {
-    current: state.voting.witnesses.currentWitnessId,
-    activeWitnesseObjects: state.voting.witnesses.activeWitnesseObjects,
-    activeWitnesseAccounts: state.voting.witnesses.activeWitnesseAccounts
+    current : state.voting.witnesses.currentWitnessId,
+    activeWitnesseObjects : state.voting.witnesses.activeWitnesseObjects,
+    activeWitnesseAccounts : state.voting.witnesses.activeWitnesseAccounts
   };
 };
 

--- a/src/components/Voting/WitnessList.jsx
+++ b/src/components/Voting/WitnessList.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Translate from 'react-translate-component';
 import {connect} from 'react-redux';
 import WitnessRow from './WitnessRow';
+import Utils from '../../common/utils';
 
 class WitnessListNew extends React.Component {
   state = {
@@ -133,7 +134,7 @@ class WitnessListNew extends React.Component {
       const aValue = this.getAccessor(a, accessor);
       const bValue = this.getAccessor(b, accessor);
 
-      if (aValue && bValue) {
+      if (Utils.isEmptyObject(aValue) && Utils.isEmptyObject(bValue)) {
         if (newSortDir[col]) {
           return aValue > bValue ? 1 : -1;
         } else if (!newSortDir[col]) {

--- a/src/components/Voting/WitnessList.jsx
+++ b/src/components/Voting/WitnessList.jsx
@@ -1,17 +1,26 @@
 import React from 'react';
 import Translate from 'react-translate-component';
-import WitnessRow from './WitnessRow';
 import {connect} from 'react-redux';
+import WitnessRow from './WitnessRow';
 
 class WitnessListNew extends React.Component {
-  shouldComponentUpdate(nextProps) {
-    return (
-      nextProps.current !== this.props.current
-    );
+  state = {
+    initialRowData: [],
+    rowData: [],
+    ranks: [],
+    sortDirections: { // true = ascend, false = descend
+      rank: 'default',
+      name: 'default',
+      last_block: 'default',
+      last_confirmed: 'default',
+      total_missed: 'default',
+      votes: 'default'
+    }
   }
 
-  render() {
-    let {inverseSort, activeWitnesseAccounts, activeWitnesseObjects} = this.props;
+  componentDidMount() {
+    // Get initial data and set to state
+    let {activeWitnesseAccounts, activeWitnesseObjects} = this.props;
     let most_recent_aslot = 0;
     let ranks = {};
     let witnesses = activeWitnesseObjects;
@@ -55,23 +64,9 @@ class WitnessListNew extends React.Component {
         }
 
         return true;
-      }).sort((a, b) => {
-        let a_account = activeWitnesseAccounts.get(a.witness_account);
-        let b_account = activeWitnesseAccounts.get(b.witness_account);
-
-        if (!a_account || !b_account) {
-          return 0;
-        }
-
-        if (a_account.votes > b_account.votes) {
-          return inverseSort ? 1 : -1;
-        } else if (a_account.votes < b_account.votes) {
-          return inverseSort ? -1 : 1;
-        } else {
-          return 0;
-        }
       }).map((a) => {
         let a_account = activeWitnesseAccounts.get(a.witness_account);
+
         return (
           <WitnessRow
             key={ a.id }
@@ -81,20 +76,113 @@ class WitnessListNew extends React.Component {
           />
         );
       });
+
+      this.setState({
+        initialRowData: itemRows,
+        rowData: itemRows,
+        ranks
+      });
+    }
+  }
+
+  // Modify the sort direction on the column header
+  sortBy = (col) => {
+    // Determine column accessor
+    let accessor;
+
+    switch(col) {
+      case 'rank':
+        accessor = 'props.rank';
+        break;
+      case 'name':
+        accessor = 'props.witnessAccount.name';
+        break;
+      case 'last_block':
+        accessor = 'props.witness.last_aslot';
+        break;
+      case 'last_confirmed':
+        accessor = 'props.witness.last_confirmed_block_num';
+        break;
+      case 'total_missed':
+        accessor = 'props.witness.total_missed';
+        break;
+      case 'votes':
+        accessor = 'props.witness.total_votes';
+        break;
+      default:
+        break;
     }
 
+    // Set the column sort indicator for the clicked column header and remove the icon for the rest
+    let newSortDir = this.state.sortDirections;
+
+    Object.keys(newSortDir).forEach((k) => {
+      if (k !== col) {
+        newSortDir[k] = 'default';
+      }
+    });
+
+    if (this.state.sortDirections[col] === 'default') {
+      newSortDir[col] = false;
+    } else {
+      newSortDir[col] = !this.state.sortDirections[col];
+    }
+
+    // Get current sort direction for clicked column header and invert (setState is async so no guarantee it has updated)
+    let sortedItemRows = this.state.rowData.sort((a, b) => {
+      let aValue = this.getAccessor(a, accessor);
+      let bValue = this.getAccessor(b, accessor);
+
+      if (newSortDir[col]) {
+        return aValue > bValue ? 1 : -1;
+      } else if (!newSortDir[col]) {
+        return aValue < bValue ? 1 : -1;
+      }
+
+      return this.state.initialRowData; // return initial data
+    });
+
+    this.setState({
+      sortDirections: newSortDir, // Invert sort direction
+      rowData: sortedItemRows
+    });
+  }
+
+  getAccessor = (obj, str) => {
+    str = str.replace(/\[(\w+)\]/g, '.$1'); // convert indexes to properties
+    str = str.replace(/^\./, '');           // strip a leading dot
+    var a = str.split('.');
+
+    for (var i = 0, n = a.length; i < n; ++i) {
+      var k = a[i];
+
+      if (k in obj) {
+        obj = obj[k];
+      } else {
+        return;
+      }
+    }
+
+    return obj;
+  }
+
+  render() {
+    const {rowData, sortDirections} = this.state;
+
     return (
-      <div className='table table2 table-voting-witnesses2'>
-        <div className='table__head tableRow'>
-          <div className='tableCell'><Translate content='witnesses.rank'/></div>
-          <div className='tableCell'><Translate content='votes.name'/></div>
-          <div className='tableCell text_r'><Translate content='witnesses.last_block'/></div>
-          <div className='tableCell text_r'><Translate content='witnesses.last_confirmed'/></div>
-          <div className='tableCell text_r'><Translate content='witnesses.missed'/></div>
-          <div className='tableCell text_r'><Translate content='votes.votes'/></div>
-        </div>
-        <div className='table__body'>
-          {itemRows}
+      <div>
+        <div className='table table2 table-voting-witnesses2'>
+          <div className='table__head tableRow'>
+            <div className={ `tableCell sort--${sortDirections.rank}` } onClick={ () => this.sortBy('rank') }><Translate content='witnesses.rank'/></div>
+            <div className={ `tableCell sort--${sortDirections.name}` } onClick={ () => this.sortBy('name') }><Translate content='votes.name'/></div>
+            <div className={ `tableCell text_r sort--${sortDirections.last_block}` } onClick={ () => this.sortBy('last_block') }><Translate content='witnesses.last_block'/></div>
+            <div className={ `tableCell text_r sort--${sortDirections.last_confirmed}` } onClick={ () => this.sortBy('last_confirmed') }><Translate content='witnesses.last_confirmed'/></div>
+            <div className={ `tableCell text_r sort--${sortDirections.total_missed}` } onClick={ () => this.sortBy('total_missed') }><Translate content='witnesses.missed'/></div>
+            <div className={ `tableCell text_r sort--${sortDirections.votes}` } onClick={ () => this.sortBy('votes') }><Translate content='votes.votes'/></div>
+          </div>
+          <div className='table__body'>
+            {rowData}
+          </div>
         </div>
       </div>
     );
@@ -105,9 +193,7 @@ const mapStateToProps = (state) => {
   return {
     current : state.voting.witnesses.currentWitnessId,
     activeWitnesseObjects : state.voting.witnesses.activeWitnesseObjects,
-    activeWitnesseAccounts : state.voting.witnesses.activeWitnesseAccounts,
-    sortBy : state.voting.witnesses.sortBy,
-    inverseSort : state.voting.witnesses.inverseSort
+    activeWitnesseAccounts : state.voting.witnesses.activeWitnesseAccounts
   };
 };
 

--- a/src/components/Voting/WitnessList.jsx
+++ b/src/components/Voting/WitnessList.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import Translate from 'react-translate-component';
 import {connect} from 'react-redux';
 import WitnessRow from './WitnessRow';
-import Utils from '../../common/utils';
 
 class WitnessListNew extends React.Component {
   state = {
@@ -134,7 +133,7 @@ class WitnessListNew extends React.Component {
       const aValue = this.getAccessor(a, accessor);
       const bValue = this.getAccessor(b, accessor);
 
-      if (Utils.isEmptyObject(aValue) && Utils.isEmptyObject(bValue)) {
+      if (aValue && bValue) {
         if (newSortDir[col]) {
           return aValue > bValue ? 1 : -1;
         } else if (!newSortDir[col]) {


### PR DESCRIPTION
column sorting within the witness stats table in the lower table within the voting > witnesses page
(accessed via the GPOS panel)

## Purpose

The purpose to this PR is to enable sorting within the Witness Stats data table within the Witness Voting section of the wallet.

![image](https://user-images.githubusercontent.com/36667230/76530317-54bd2800-6452-11ea-97d3-80275b96e381.png)

## Instructions to Verify

**Steps To Reproduce:**

1. Login to the Peerplays Core GUI
2. Click participate in the right hand GPOS section (if you have powered up yet, this will say "Get Started" and you will have to perform a Power Up to unlock the voting mechanism)
3. Click "Vote"
4. Click the "Witness" tab
5. Scroll to the bottom of this tab content to see the bottom table that has the sortable data

**Expected Behavior**

Clicking a table header within the GPOS modal screen > voting > witnesses should switch table data sorting based on the columns data.

### Declarations

Check these if you believe they are true

* [X] The code base is in a better state after this PR
* [X] Is prepared according to the [Release Management & Versioning](https://github.com/peerplays-network/peerplays/wiki/Release-Management-&-Versioning)
* [X] The level of testing this PR includes is appropriate
* [ ] All tests pass using the self-service CI/Gitlab.
* [X] Changes to the codebase are well documented
* [X] Testing steps for the QA team / community is shared

### Reviewers

@MuffinLightning @aametzler 

### Closing issues

Closes Jira issue GPOS-68