### PR TITLE
style: fix: react-tabs inactive wrong cursor style

### DIFF
--- a/src/assets/stylesheets/modules/_react_tabs.scss
+++ b/src/assets/stylesheets/modules/_react_tabs.scss
@@ -48,6 +48,7 @@
 
       &:hover {
         opacity: .6;
+        cursor: pointer;
       }
 
       &[aria-selected=true] {

--- a/src/assets/stylesheets/modules/_table.scss
+++ b/src/assets/stylesheets/modules/_table.scss
@@ -445,6 +445,22 @@
     border-bottom: 1px solid $th-bd-color;
     color: $th-color;
 
+    &.sort {
+      cursor: pointer;
+
+      &--true, &--false, &--default {
+        @extend .tableCell.sort;
+      }
+
+      &--true::after { // ascend
+        content: ' ▲';
+      }
+
+      &--false::after { // descend
+        content: ' ▼';
+      }
+    }
+
     &:first-child {
       @include border-radius(4px 0 0 0);
     }
@@ -452,6 +468,12 @@
     &:last-child {
       @include border-radius(0 4px 0 0);
     }
+  }
+}
+
+.table-voting-witnesses2 .tableRow {
+  &.sortable {
+    cursor: pointer;
   }
 }
 

--- a/src/components/Voting/WitnessList.jsx
+++ b/src/components/Voting/WitnessList.jsx
@@ -1,17 +1,26 @@
 import React from 'react';
 import Translate from 'react-translate-component';
-import WitnessRow from './WitnessRow';
 import {connect} from 'react-redux';
+import WitnessRow from './WitnessRow';
 
 class WitnessListNew extends React.Component {
-  shouldComponentUpdate(nextProps) {
-    return (
-      nextProps.current !== this.props.current
-    );
+  state = {
+    initialRowData: [],
+    rowData: [],
+    ranks: [],
+    sortDirections: { // true = ascend, false = descend
+      rank: 'default',
+      name: 'default',
+      last_block: 'default',
+      last_confirmed: 'default',
+      total_missed: 'default',
+      votes: 'default'
+    }
   }
 
-  render() {
-    let {inverseSort, activeWitnesseAccounts, activeWitnesseObjects} = this.props;
+  componentDidMount() {
+    // Get initial data and set to state
+    let {activeWitnesseAccounts, activeWitnesseObjects} = this.props;
     let most_recent_aslot = 0;
     let ranks = {};
     let witnesses = activeWitnesseObjects;
@@ -55,23 +64,9 @@ class WitnessListNew extends React.Component {
         }
 
         return true;
-      }).sort((a, b) => {
-        let a_account = activeWitnesseAccounts.get(a.witness_account);
-        let b_account = activeWitnesseAccounts.get(b.witness_account);
-
-        if (!a_account || !b_account) {
-          return 0;
-        }
-
-        if (a_account.votes > b_account.votes) {
-          return inverseSort ? 1 : -1;
-        } else if (a_account.votes < b_account.votes) {
-          return inverseSort ? -1 : 1;
-        } else {
-          return 0;
-        }
       }).map((a) => {
         let a_account = activeWitnesseAccounts.get(a.witness_account);
+
         return (
           <WitnessRow
             key={ a.id }
@@ -81,20 +76,113 @@ class WitnessListNew extends React.Component {
           />
         );
       });
+
+      this.setState({
+        initialRowData: itemRows,
+        rowData: itemRows,
+        ranks
+      });
+    }
+  }
+
+  // Modify the sort direction on the column header
+  sortBy = (col) => {
+    // Determine column accessor
+    let accessor;
+
+    switch(col) {
+      case 'rank':
+        accessor = 'props.rank';
+        break;
+      case 'name':
+        accessor = 'props.witnessAccount.name';
+        break;
+      case 'last_block':
+        accessor = 'props.witness.last_aslot';
+        break;
+      case 'last_confirmed':
+        accessor = 'props.witness.last_confirmed_block_num';
+        break;
+      case 'total_missed':
+        accessor = 'props.witness.total_missed';
+        break;
+      case 'votes':
+        accessor = 'props.witness.total_votes';
+        break;
+      default:
+        break;
     }
 
+    // Set the column sort indicator for the clicked column header and remove the icon for the rest
+    let newSortDir = this.state.sortDirections;
+
+    Object.keys(newSortDir).forEach((k) => {
+      if (k !== col) {
+        newSortDir[k] = 'default';
+      }
+    });
+
+    if (this.state.sortDirections[col] === 'default') {
+      newSortDir[col] = false;
+    } else {
+      newSortDir[col] = !this.state.sortDirections[col];
+    }
+
+    // Get current sort direction for clicked column header and invert (setState is async so no guarantee it has updated)
+    let sortedItemRows = this.state.rowData.sort((a, b) => {
+      let aValue = this.getAccessor(a, accessor);
+      let bValue = this.getAccessor(b, accessor);
+
+      if (newSortDir[col]) {
+        return aValue > bValue ? 1 : -1;
+      } else if (!newSortDir[col]) {
+        return aValue < bValue ? 1 : -1;
+      }
+
+      return this.state.initialRowData; // return initial data
+    });
+
+    this.setState({
+      sortDirections: newSortDir, // Invert sort direction
+      rowData: sortedItemRows
+    });
+  }
+
+  getAccessor = (obj, str) => {
+    str = str.replace(/\[(\w+)\]/g, '.$1'); // convert indexes to properties
+    str = str.replace(/^\./, '');           // strip a leading dot
+    var a = str.split('.');
+
+    for (var i = 0, n = a.length; i < n; ++i) {
+      var k = a[i];
+
+      if (k in obj) {
+        obj = obj[k];
+      } else {
+        return;
+      }
+    }
+
+    return obj;
+  }
+
+  render() {
+    const {rowData, sortDirections} = this.state;
+
     return (
-      <div className='table table2 table-voting-witnesses2'>
-        <div className='table__head tableRow'>
-          <div className='tableCell'><Translate content='witnesses.rank'/></div>
-          <div className='tableCell'><Translate content='votes.name'/></div>
-          <div className='tableCell text_r'><Translate content='witnesses.last_block'/></div>
-          <div className='tableCell text_r'><Translate content='witnesses.last_confirmed'/></div>
-          <div className='tableCell text_r'><Translate content='witnesses.missed'/></div>
-          <div className='tableCell text_r'><Translate content='votes.votes'/></div>
-        </div>
-        <div className='table__body'>
-          {itemRows}
+      <div>
+        <div className='table table2 table-voting-witnesses2'>
+          <div className='table__head tableRow'>
+            <div className={ `tableCell sort--${sortDirections.rank}` } onClick={ () => this.sortBy('rank') }><Translate content='witnesses.rank'/></div>
+            <div className={ `tableCell sort--${sortDirections.name}` } onClick={ () => this.sortBy('name') }><Translate content='votes.name'/></div>
+            <div className={ `tableCell text_r sort--${sortDirections.last_block}` } onClick={ () => this.sortBy('last_block') }><Translate content='witnesses.last_block'/></div>
+            <div className={ `tableCell text_r sort--${sortDirections.last_confirmed}` } onClick={ () => this.sortBy('last_confirmed') }><Translate content='witnesses.last_confirmed'/></div>
+            <div className={ `tableCell text_r sort--${sortDirections.total_missed}` } onClick={ () => this.sortBy('total_missed') }><Translate content='witnesses.missed'/></div>
+            <div className={ `tableCell text_r sort--${sortDirections.votes}` } onClick={ () => this.sortBy('votes') }><Translate content='votes.votes'/></div>
+          </div>
+          <div className='table__body'>
+            {rowData}
+          </div>
         </div>
       </div>
     );
@@ -105,9 +193,7 @@ const mapStateToProps = (state) => {
   return {
     current : state.voting.witnesses.currentWitnessId,
     activeWitnesseObjects : state.voting.witnesses.activeWitnesseObjects,
-    activeWitnesseAccounts : state.voting.witnesses.activeWitnesseAccounts,
-    sortBy : state.voting.witnesses.sortBy,
-    inverseSort : state.voting.witnesses.inverseSort
+    activeWitnesseAccounts : state.voting.witnesses.activeWitnesseAccounts
   };
 };
 


### PR DESCRIPTION
### Purpose

Resolve bug where there is an incorrect cursor in wallet voting area tabs.

The GitHub issue is: #139 

## Instructions to Verify

**Steps To Reproduce:**

[Provide Steps to reproduce the issue or patterns/regular expression to look for in the CI]

**Expected Behavior**

1. Login to wallet
2. Click on Participate/Get Started
3. Click on Vote button (Power Up if vote button is disabled)
4. Vote dialog will open, Hover over each tab - Proxy, Witness or Advisors

Mouse pointer changes in to Hand pointer on hover over tab. Active tab has default OS cursor.

### Declarations

Check these if you believe they are true

* [X] The code base is in a better state after this PR
* [X] Is prepared according to the [Release Management & Versioning](https://github.com/peerplays-network/peerplays/wiki/Release-Management-&-Versioning)
* [X] The level of testing this PR includes is appropriate
* [ ] Testing steps for the QA team / community is shared

### Reviewers

@aametzler

### Closing issues

Closes #139 
Resolves GPOS-67