### PR TITLE
fix(voting): remove `disabled` check on Publish button

### DIFF
--- a/src/components/Voting/CommitteeMembers.jsx
+++ b/src/components/Voting/CommitteeMembers.jsx
@@ -320,7 +320,7 @@ class CommitteeMembers extends React.Component {
                   type='button'
                   className='btn btn-success'
                   onClick={ this.onPublishChanges.bind(this, this.props.walletLocked) }
-                  disabled={ disabled || proxyIsEnabled }>
+                  disabled={ proxyIsEnabled }>
                   <Translate content='votes.publish'/>
                 </button>
               </div>

--- a/src/components/Voting/Witnesses.jsx
+++ b/src/components/Voting/Witnesses.jsx
@@ -354,7 +354,7 @@ class Witnesses extends React.Component {
                 type='button'
                 className='btn btn-success'
                 onClick={ this.onPublishChanges.bind(this, this.props.walletLocked) }
-                disabled={ disabled || proxyIsEnabled }>
+                disabled={ proxyIsEnabled }>
                 <Translate content='votes.publish'/>
               </button>
             </div>


### PR DESCRIPTION
by removing the disabled check on the publish button, we can always perform a publish action thereby
allowing a user to "re-vote" without extra charges

### Purpose

To allow re-voting of previously voted witnesses and advisors without the need to remove the vote, publish, re-add the vote, and then publish again (two fee charges when there should be one).

The GitHub issue is #142

## Instructions to Verify

**Steps To Reproduce:**

1. Login to wallet gui
2. Click "Participate"
3. Click "Vote" (power up if you cannot click)
4. Click "Witness" or "Advisor"
5. Add a witness/advisor
6. Click "Publish" and proceed through the confirmation pop-up
7. Repeast step 6

**Expected Behavior**

As a user, I should always be able to click the Publish button in the vote section of the GUI Wallet except when I have a proxy set.

### Declarations

Check these if you believe they are true

* [x] The code base is in a better state after this PR
* [x] Is prepared according to the [Release Management & Versioning](https://github.com/peerplays-network/peerplays/wiki/Release-Management-&-Versioning)
* [x] The level of testing this PR includes is appropriate
* [x] All tests pass using the self-service CI/Gitlab.
* [ ] Testing steps for the QA team / community is shared

### Reviewers

@aametzler 

### Closing issues

Resolves GPOS-74 
Closes #142